### PR TITLE
CON-3068 CON-3069 CON-3070 use role graph and set of existing resources during planning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,3 +9,4 @@ gemspec
 gem 'simplecov', require: false
 gem 'conjur-policy-parser', github: 'conjurinc/conjur-policy-parser', branch: 'master'
 gem 'conjur-asset-authn-local', git: 'https://github.com/conjurinc/conjur-asset-authn-local.git', branch: 'master'
+gem 'conjur-api', :github => 'conjurinc/api-ruby', :branch => 'ldap-sync-perf_160622'

--- a/Gemfile
+++ b/Gemfile
@@ -9,4 +9,4 @@ gemspec
 gem 'simplecov', require: false
 gem 'conjur-policy-parser', github: 'conjurinc/conjur-policy-parser', branch: 'master'
 gem 'conjur-asset-authn-local', git: 'https://github.com/conjurinc/conjur-asset-authn-local.git', branch: 'master'
-gem 'conjur-api', :github => 'conjurinc/api-ruby', :branch => 'ldap-sync-perf_160622'
+gem 'conjur-api', :github => 'conjurinc/api-ruby', :branch => 'master'

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -1,7 +1,5 @@
 #!/bin/bash -ex
 
-echo 127.0.0.1 conjur >> /etc/hosts
-
 /opt/conjur/evoke/bin/wait_for_conjur
 
 cd /src/conjur-asset-policy

--- a/conjur-asset-policy.gemspec
+++ b/conjur-asset-policy.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "safe_yaml"
   spec.add_dependency "conjur-policy-parser"
 
+  spec.add_development_dependency "conjur-api", '~> 4.26'
   spec.add_development_dependency "conjur-cli"
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/conjur-asset-policy.gemspec
+++ b/conjur-asset-policy.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec-expectations"
-  spec.add_development_dependency "pry"
+  spec.add_development_dependency "pry-byebug"
   spec.add_development_dependency "json_spec"
   spec.add_development_dependency "cucumber"
   spec.add_development_dependency "ci_reporter_rspec"

--- a/features/existence.feature
+++ b/features/existence.feature
@@ -1,0 +1,93 @@
+Feature: Planning can do existence and adminship checks
+
+  Scenario: Planning sees an existing record
+    Given I load the policy "- !group ops"
+    When I plan the policy as yaml:
+    """
+    ---
+    - !group ops
+    """
+    Then the normalized stdout should contain "--- []"
+
+  Scenario: Planning sees an existing resource
+    Given I load the policy:
+    """
+    ---
+    - !resource
+      id: webservice1
+      kind: webservice
+    """
+    When I plan the policy as yaml:
+    """
+    ---
+    - !resource 
+      id: webservice1
+      kind: webservice
+    """
+    Then the normalized stdout should contain "--- []"
+
+  Scenario: Planning sees an existing role
+    Given I load the policy:
+    """
+    ---
+    - !role
+      id: service
+      kind: robot
+    """
+    When I plan the policy as yaml:
+    """
+    ---
+    - !role
+      id: service
+      kind: robot
+    """
+    Then the normalized stdout should contain "--- []"
+
+  @announce-output
+  Scenario: Planning sees an owner as an admin
+    Given I load the policy:
+    """
+    ---
+    - !user owner
+    - !group
+      id: ops
+      owner: !user owner
+    """
+    When I plan the policy as yaml:
+    """
+    ---
+    - !grant
+      role: !group ops
+      members:
+        - !member
+          role: !user owner
+          admin: true        
+    """
+    Then the normalized stdout should contain "--- []"
+
+  Scenario: Planning sees an existing adminship
+    Given I load the policy:
+    """
+    ---
+    - !user owner
+    - !group
+      id: ops
+    - !grant
+      role: !group ops
+      members:
+        - !member
+          role: !user owner
+          admin: true        
+
+    """
+    When I plan the policy as yaml:
+    """
+    ---
+    - !grant
+      role: !group ops
+      members:
+        - !member
+          role: !user owner
+          admin: true        
+    """
+    Then the normalized stdout should contain "--- []"

--- a/features/existence.feature
+++ b/features/existence.feature
@@ -43,7 +43,6 @@ Feature: Planning can do existence and adminship checks
     """
     Then the normalized stdout should contain "--- []"
 
-  @announce-output
   Scenario: Planning sees an owner as an admin
     Given I load the policy:
     """

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -10,7 +10,7 @@ if [ -z "$CONJUR_CONTAINER" ]; then
 	    docker pull $DOCKER_IMAGE
 	fi
 	
-	cid=$(docker run --privileged -d -v ${PWD}:/src/conjur-asset-policy $DOCKER_IMAGE)
+	cid=$(docker run --privileged -d --add-host conjur:127.0.0.1 -v ${PWD}:/src/conjur-asset-policy $DOCKER_IMAGE)
 	function finish {
     	if [ "$NOKILL" != "1" ]; then
 			docker rm -f ${cid}

--- a/lib/conjur/policy/executor/update.rb
+++ b/lib/conjur/policy/executor/update.rb
@@ -44,15 +44,17 @@ module Conjur::Policy::Executor
     def execute
       super
 
-      if record.public_keys
-        (Array(record.public_keys) - user.public_keys).each do |key|
+      record_keys = record.public_keys
+      user_keys = user.public_keys
+      if record_keys
+        (Array(record_keys) - user_keys).each do |key|
           action({
             'method' => 'post',
             'path' => public_key_path,
             'parameters' => key
           })
         end
-        (user.public_keys - Array(record.public_keys)).each do |key|
+        (user_keys - Array(record_keys)).each do |key|
           action({
             'method' => 'delete',
             'path' => [ public_key_path, CGI.escape(key_name(key)) ].join('/')

--- a/lib/conjur/policy/plan.rb
+++ b/lib/conjur/policy/plan.rb
@@ -26,6 +26,11 @@ module Conjur
         @existing_resources.include?(id)
       end
 
+      def can_admin_role?(admin, role)
+        raise "no admin_option support in role graph" if @current_role_graph.first.admin_option.nil?
+        @current_role_graph.any? {|e| e.parent == role && e.child == admin && e.admin_option }
+      end
+
     end
   end
 end

--- a/lib/conjur/policy/plan.rb
+++ b/lib/conjur/policy/plan.rb
@@ -2,16 +2,28 @@ module Conjur
   module Policy
     class Plan
       attr_reader :actions, :roles_created, :resources_created
-      
-      def initialize
+
+      def initialize(existing_resources, current_role_graph)
         @actions = []
         @roles_created = Set.new
         @resources_created = Set.new
+        @existing_resources = Set.new(existing_resources.collect {|r| r.resourceid})
+        @existing_roles = Set.new
+        current_role_graph.inject(@existing_roles) {|roles, edge| roles.add(edge.parent).add(edge.child)}
       end
       
       def action a
         @actions.push a
       end
+
+      def role_exists?(id)
+        @existing_roles.include?(id)
+      end
+
+      def resource_exists?(id)
+        @existing_resources.include?(id)
+      end
+
     end
   end
 end

--- a/lib/conjur/policy/plan.rb
+++ b/lib/conjur/policy/plan.rb
@@ -7,9 +7,11 @@ module Conjur
         @actions = []
         @roles_created = Set.new
         @resources_created = Set.new
-        @existing_resources = Set.new(existing_resources.collect {|r| r.resourceid})
-        @existing_roles = Set.new
-        current_role_graph.inject(@existing_roles) {|roles, edge| roles.add(edge.parent).add(edge.child)}
+        @existing_resources = Set.new(existing_resources.collect(&:resourceid))
+        # $stderr.puts "@existing_resources: #{@existing_resources.inspect}"
+        @current_role_graph = current_role_graph
+        @existing_roles = current_role_graph.inject(Set.new) {|roles, edge| roles.add(edge.parent).add(edge.child)}
+        # $stderr.puts "existing roles: #{@existing_roles.inspect}"
       end
       
       def action a

--- a/lib/conjur/policy/plan.rb
+++ b/lib/conjur/policy/plan.rb
@@ -8,10 +8,8 @@ module Conjur
         @roles_created = Set.new
         @resources_created = Set.new
         @existing_resources = Set.new(existing_resources.collect(&:resourceid))
-        # $stderr.puts "@existing_resources: #{@existing_resources.inspect}"
         @current_role_graph = current_role_graph
         @existing_roles = current_role_graph.inject(Set.new) {|roles, edge| roles.add(edge.parent).add(edge.child)}
-        # $stderr.puts "existing roles: #{@existing_roles.inspect}"
       end
       
       def action a

--- a/lib/conjur/policy/planner.rb
+++ b/lib/conjur/policy/planner.rb
@@ -8,7 +8,7 @@ module Conjur
     module Planner
       class << self
         def plan records, api, plan = nil
-          plan ||= Plan.new
+          plan ||= Plan.new(api.resources(:kind => 'user') + api.resources(:kind => 'group'), api.role_graph(api.current_role))
           plan.tap do |plan|
             Array(records).map{ |record| planner_for(record, api) }.each do |planner|
               planner.plan = plan
@@ -31,6 +31,7 @@ module Conjur
           end
           cls.new record, api
         end
+          
       end
     end
   end

--- a/lib/conjur/policy/planner.rb
+++ b/lib/conjur/policy/planner.rb
@@ -8,7 +8,7 @@ module Conjur
     module Planner
       class << self
         def plan records, api, plan = nil
-          plan ||= Plan.new(api.resources(:kind => 'user') + api.resources(:kind => 'group'), api.role_graph(api.current_role))
+          plan ||= Plan.new(api.resources, api.role_graph(api.current_role))
           plan.tap do |plan|
             Array(records).map{ |record| planner_for(record, api) }.each do |planner|
               planner.plan = plan

--- a/lib/conjur/policy/planner/base.rb
+++ b/lib/conjur/policy/planner/base.rb
@@ -39,7 +39,7 @@ module Conjur
 
         def resource_exists? resource
           resource_id = resource.respond_to?(:resourceid) ? resource.resourceid : resource.to_s
-          plan.resources_created.include?(resource_id) ||  plan.resource_exists?(resource_id) || api.resource(resource_id).exists?
+          plan.resources_created.include?(resource_id) ||  plan.resource_exists?(resource_id)
         end
 
         def role_exists? role
@@ -54,7 +54,7 @@ module Conjur
             role_kind = role_tokens.shift
             role_id = [ account, role_kind, role_tokens.join('/') ].join(":")
           end
-          plan.roles_created.include?(role_id) || plan.role_exists?(role_id) || api.role(role_id).exists?
+          plan.roles_created.include?(role_id) || plan.role_exists?(role_id)
         end
 
         def error message
@@ -120,7 +120,7 @@ module Conjur
           end
 
           if record.role?
-            unless api.role(record.owner.roleid).can_admin_role?(role)
+            unless plan.can_admin_role?(record.owner.roleid, record.roleid)
               log { "Role will be granted to #{record.owner.roleid} with admin option" }
   
               grant = Conjur::Policy::Types::Grant.new

--- a/lib/conjur/policy/planner/record.rb
+++ b/lib/conjur/policy/planner/record.rb
@@ -5,7 +5,7 @@ module Conjur
     module Planner      
       module ActsAsRecord
         def do_plan
-          if object.exists?
+          if exists?
             update_record
           else
             create_record
@@ -21,12 +21,22 @@ module Conjur
         include ActsAsRecord
         
         alias object role
+
+        def exists?
+          plan.role_exists?(role.roleid)
+        end
+
       end
       
       class Resource < Base
         include ActsAsRecord
         
         alias object resource
+
+        def exists?
+          plan.resource_exists?(resource.resourceid)
+        end
+
       end
       
       class Record < Base
@@ -36,6 +46,11 @@ module Conjur
           raise "Cannot create a record in non-default account #{record.account}" unless record.account == Conjur.configuration.account
           @object ||= api.send(record.resource_kind, record.id)
         end
+
+        def exists?
+          plan.resource_exists?(object.resourceid)
+        end
+
       end
       
       class Webservice < Resource

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -182,7 +182,7 @@ class MockAPI
   end
 
   def resources(options = {})
-    existing_resources.select { |rsrc| options[:kind].present? || rsrc.kind == options[:kind] }
+    existing_resources.select { |rsrc| !options[:kind] || rsrc.kind == options[:kind] }
   end
 
   def role_graph role

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -186,7 +186,7 @@ class MockAPI
   end
 
   def role_graph role
-    @role_graph ||= Conjur::Graph.new(@records.select(&:role?).collect {|r| [r.roleid, r.owner.roleid]})
+    @role_graph ||= Conjur::Graph.new(@records.select(&:role?).collect {|r| [r.roleid, r.owner.roleid, true]})
   end
 
   def resource id

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
+
 require 'simplecov'
 SimpleCov.start do
   add_filter '/spec/'
@@ -65,6 +66,10 @@ end
 class MockRole
   include MockAsset
 
+  def roleid
+    @record.try(:roleid)
+  end
+
   def role?
     true
   end
@@ -93,11 +98,19 @@ end
 class MockResource
   include MockAsset
 
+  def resourceid
+    @record.try(:resourceid)
+  end
+
+  def kind
+    @record.class.short_name.underscore
+  end
+
   def exists?
     !!@record
   end
 
-  def resource?;
+  def resource?
     true;
   end
 
@@ -119,6 +132,10 @@ end
 
 class MockRecord
   include MockAsset
+
+  def resourceid
+    @record.try(:resourceid)
+  end
 
   def exists?
     !!@record
@@ -149,14 +166,27 @@ class MockVariable < MockRecord
 end
 
 class MockAPI
-  attr_reader :account, :records
+  attr_reader :account, :records, :existing_resources
 
   def initialize account, records
     @account = account
     @records = records
+    @existing_resources = @records.collect {|r| MockResource.new(self, r) if r.resource?}.compact
     @roles_by_id = { 'the-account:user:default-owner' => MockRole.new(self, Types::User.new('default-owner').tap{|u| u.account = 'the-account'}) }
     @resources_by_id = {}
     @records_by_id = {}
+  end
+
+  def current_role
+    role 'the-account:user:default-owner'
+  end
+
+  def resources(options = {})
+    existing_resources.select { |rsrc| options[:kind].present? || rsrc.kind == options[:kind] }
+  end
+
+  def role_graph role
+    @role_graph ||= Conjur::Graph.new(@records.select(&:role?).collect {|r| [r.roleid, r.owner.roleid]})
   end
 
   def resource id


### PR DESCRIPTION
Query Conjur for the set of existing resources and the role graph. Use these sets during planning to avoid sending existence checks to the server. Also use the role graph to determine whether one role can admin another. Finally, memoize the sync'ed role/resource to avoid extra API calls for them, and only fetch a user's pubkey once.